### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,9 +28,8 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(item_params)
-
-    if @item.save
+    
+    if @item.update(item_params)
       redirect_to root_path
     else
       render :edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
+  before_action :set_tweet, only: [:edit, :show, :update]
 
   def index
     @items = Item.all.includes(:user).order('created_at DESC')
@@ -20,16 +21,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to new_user_session_path unless @item.user_id == current_user.id
   end
 
   def update
-    @item = Item.find(params[:id])
     @item.update(item_params)
 
     if @item.save
@@ -55,5 +53,9 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :name, :description, :price, :category_id, :status_id, :delivery_fee_id, :shipment_source_id, :day_to_ship_id).merge(user_id: current_user.id)
+  end
+
+  def set_tweet
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,36 +9,36 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
-  # def create
-  #   @item = Item.new(item_params)
+  def create
+    @item = Item.new(item_params)
 
-  #   if @item.save
-  #     redirect_to root_path
-  #   else
-  #     render :new
-  #   end
-  # end
+    if @item.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
 
   def show
     @item = Item.find(params[:id])
   end
 
-  # def edit
-  #   @item = Item.find(params[:id])
-  #   redirect_to new_user_session_path unless @item.user_id == current_user.id
-  # end
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to new_user_session_path unless @item.user_id == current_user.id
+  end
 
-  # def update
-  #   @item = Item.find(params[:id])
-  #   @item.update(item_params)
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
 
-  #   if @item.save
-  #     redirect_to root_path
-  #   else
-  #     render :edit
+    if @item.save
+      redirect_to root_path
+    else
+      render :edit
 
-  #   end
-  # end
+    end
+  end
 
   # def destroy
   #   item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to new_user_session_path unless @item.user_id == current_user.id
+    redirect_to item_path  unless @item.user_id == current_user.id
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_tweet, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update]
 
   def index
     @items = Item.all.includes(:user).order('created_at DESC')
@@ -55,7 +55,7 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:image, :name, :description, :price, :category_id, :status_id, :delivery_fee_id, :shipment_source_id, :day_to_ship_id).merge(user_id: current_user.id)
   end
 
-  def set_tweet
+  def set_item
     @item = Item.find(params[:id])
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -100,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <% <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
+           <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> 
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -100,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
+          <% <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %> %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>


### PR DESCRIPTION
# what
商品情報編集機能の実装

# why
ユーザーが投稿した商品の情報を編集することができるようにするため。

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/091d1a324add7cc2684d77df473b801b

エラーハンドリング
https://gyazo.com/d45264efa86e45993805997e78eebde3

 ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
https://gyazo.com/f9390a03730874de566ed597638abc16

ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/d6c6e1a4f1e222f32ae74d278511fbd8
